### PR TITLE
Assume "Operational" print_job_state unless we know otherwise

### DIFF
--- a/OctoPrintOutputDevice.py
+++ b/OctoPrintOutputDevice.py
@@ -634,7 +634,7 @@ class OctoPrintOutputDevice(NetworkedPrinterOutputDevice):
                     else:
                         print_job = printer.activePrintJob
 
-                    print_job_state = "offline"
+                    print_job_state = "ready"
                     if "state" in json_data:
                         if json_data["state"] == "Error":
                             print_job_state = "error"


### PR DESCRIPTION
Continued from https://github.com/probonopd/WirelessPrinting/issues/30#issuecomment-467097709.

I think this change does not hurt users using the plugin with OctoPrint, but it does help users using [WirelessPrinting](https://github.com/probonopd/WirelessPrinting) (an ESP8266 implementation of a subset of the OctoPrint API). This patch removes the "Lost connection with the printer" error.

Looks like the Cura OctoPrint plugin has changed, and in addition to `printer_state` there is now `print_job_state` which must not be "offline", or else we will get "Lost connection with the printer". I am at a loss in understanding how `print_job_state` is put together and why it might ever be different from `printer_state` but I can confirm that with this change it works for me.