### PR TITLE
Handle NoneType readings for hotends too

### DIFF
--- a/OctoPrintOutputDevice.py
+++ b/OctoPrintOutputDevice.py
@@ -559,8 +559,10 @@ class OctoPrintOutputDevice(NetworkedPrinterOutputDevice):
                             extruder = printer.extruders[index]
                             if ("tool%d" % index) in json_data["temperature"]:
                                 hotend_temperatures = json_data["temperature"]["tool%d" % index]
-                                extruder.updateTargetHotendTemperature(hotend_temperatures["target"])
-                                extruder.updateHotendTemperature(hotend_temperatures["actual"])
+                                target_temperature = hotend_temperatures["target"] if hotend_temperatures["target"] is not None else -1
+                                actual_temperature = hotend_temperatures["actual"] if hotend_temperatures["actual"] is not None else -1
+                                extruder.updateTargetHotendTemperature(target_temperature)
+                                extruder.updateHotendTemperature(actual_temperature)
                             else:
                                 extruder.updateTargetHotendTemperature(0)
                                 extruder.updateHotendTemperature(0)


### PR DESCRIPTION
Same fix as for bed temps but for hotends too.

This stops cura from crashing if for example your klipper device is not yet powered so no data is available yet.