### PR TITLE
CMakeLists.txt: install qml files in qml subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,15 +5,19 @@ install(FILES
     __init__.py
     plugin.json
     DiscoverOctoPrintAction.py
-    DiscoverOctoPrintAction.qml
-    OctoPrintComponents.qml
     OctoPrintOutputDevice.py
     OctoPrintOutputDevicePlugin.py
     NetworkMJPGImage.py
     zeroconf.py
-    MonitorItem3x.qml
-    MonitorItem4x.qml
     LICENSE
     README.md
     DESTINATION lib/cura/plugins/OctoPrintPlugin
+)
+
+install(FILES
+    qml/DiscoverOctoPrintAction.qml
+    qml/OctoPrintComponents.qml
+    qml/MonitorItem3x.qml
+    qml/MonitorItem4x.qml
+    DESTINATION lib/cura/plugins/OctoPrintPlugin/qml
 )


### PR DESCRIPTION
This updates the CMakeLists.txt after the qml files were moved to the `qml` directory in this commit: https://github.com/fieldOfView/Cura-OctoPrintPlugin/commit/7a241988b48c040f90eb2f0f61d2933ef1c3f9b0