### PR TITLE
fix: UnboundLocalError: local variable 'all_config_set' referenced before assignment

### DIFF
--- a/OctoPrintPowerPlugins.py
+++ b/OctoPrintPowerPlugins.py
@@ -19,8 +19,8 @@ class OctoPrintPowerPlugins():
             ("ikea_tradfri", "IKEA Trådfri", ["gateway_ip", "selected_outlet"])
         ]:
             if plugin_id in plugin_data:
+                all_config_set = True
                 for config_item in additional_data:
-                    all_config_set = True
                     if config_item not in plugin_data[plugin_id] or not plugin_data[plugin_id][config_item]:
                         all_config_set = False
                         break


### PR DESCRIPTION
When requesting an API key from octoprint Cura 4.6.1 crashes with
```
OctoPrintPlugin/OctoPrintPowerPlugins.py", line 27, in parsePluginData
    if all_config_set:
UnboundLocalError: local variable 'all_config_set' referenced before assignment

```
I have 

- Octoprint 1.4.0
- PSU control 0.1.9
- no other power plugins.

Moved variable `all_config_set` out of the for loop as it is probably intended ;-)