### PR TITLE
Allow to set upload name based on slicing parameters

### DIFF
--- a/DiscoverOctoPrintAction.py
+++ b/DiscoverOctoPrintAction.py
@@ -351,6 +351,19 @@ class DiscoverOctoPrintAction(MachineAction):
     def instanceSupportsAppKeys(self) -> bool:
         return self._instance_supports_appkeys
 
+    @pyqtSlot(str, result=str)
+    def uploadName(self, container_id: str) -> str:
+        containers = ContainerRegistry.getInstance().findContainers(id = container_id)
+        if not containers:
+            Logger.log("w", "Could not get metadata of container %s because it was not found.", container_id)
+            return
+
+        return containers[0].getMetaDataEntry("octoprint_upload_name") or "{name}"
+
+    @pyqtSlot(str, str)
+    def setUploadName(self, container_id: str, uploadName: str) -> None:
+        self.setContainerMetaDataEntry(container_id, "octoprint_upload_name", uploadName)
+
     @pyqtSlot(str, str, str)
     def setContainerMetaDataEntry(self, container_id: str, key: str, value: str) -> None:
         containers = ContainerRegistry.getInstance().findContainers(id = container_id)

--- a/OctoPrintOutputDevice.py
+++ b/OctoPrintOutputDevice.py
@@ -634,11 +634,11 @@ class OctoPrintOutputDevice(NetworkedPrinterOutputDevice):
             params["date"] = strftime("%Y-%m-%d")
 
             if print_info.materialNames:
-                params["material"] = print_info.materialNames[0]
+                params["material_name"] = print_info.materialNames[0]
             elif print_info.preSliced:
-                params["material"] = "presliced"
+                params["material_name"] = "presliced"
             else:
-                params["material"] = "undefined"
+                params["material_name"] = "undefined"
 
             for key in UploadProperties:
                 params[key] = global_container_stack.getProperty(key, "value") or ""

--- a/qml/DiscoverOctoPrintAction.qml
+++ b/qml/DiscoverOctoPrintAction.qml
@@ -343,7 +343,7 @@ Cura.MachineAction
                             UM.TooltipArea
                             {
                                 anchors.fill: parent
-                                text: catalog.i18nc("@info:tooltip", "Ex.: {name}_{layer_height}<br/><br/>- {name}<br/>- {date}<br/>- {time}<br/>- {adhesion_type}<br/>- {layer_height}<br/>- {material}<br/>- {material_print_temperature}<br/>- {material_bed_temperature}<br/>- {material_flow}<br/>- {retraction_min_travel}<br/>- {speed_print}<br/>- {cool_fan_speed}")
+                                text: catalog.i18nc("@info:tooltip", "Ex.: {name}_{layer_height}<br/><br/>- {name}<br/>- {date}<br/>- {time}<br/>- {adhesion_type}<br/>- {layer_height}<br/>- {material_name}<br/>- {material_print_temperature}<br/>- {material_bed_temperature}<br/>- {material_flow}<br/>- {retraction_min_travel}<br/>- {speed_print}<br/>- {cool_fan_speed}")
                                 acceptedButtons: Qt.NoButton
                             }
                         }

--- a/qml/DiscoverOctoPrintAction.qml
+++ b/qml/DiscoverOctoPrintAction.qml
@@ -320,8 +320,46 @@ Cura.MachineAction
                                 manager.openWebPage(base.selectedInstance.baseURL);
                             }
                         }
-
                     }
+
+                    Label
+                    {
+                        width: Math.floor(parent.width * 0.2)
+                        wrapMode: Text.WordWrap
+                        text: catalog.i18nc("@label", "Upload filename")
+                    }
+                    Row
+                    {
+                        spacing: UM.Theme.getSize("default_lining").width
+                        TextField
+                        {
+                            id: uploadName
+                            width: Math.floor(parent.parent.width * 0.5 - UM.Theme.getSize("default_margin").width)
+                            onEditingFinished:
+                            {
+                                manager.setUploadName(activeMachineId, text);
+                            }
+
+                            UM.TooltipArea
+                            {
+                                anchors.fill: parent
+                                text: catalog.i18nc("@info:tooltip", "Ex.: {name}_{layer_height}<br/><br/>- {name}<br/>- {date}<br/>- {time}<br/>- {adhesion_type}<br/>- {layer_height}<br/>- {material}<br/>- {material_print_temperature}<br/>- {material_bed_temperature}<br/>- {material_flow}<br/>- {retraction_min_travel}<br/>- {speed_print}<br/>- {cool_fan_speed}")
+                                acceptedButtons: Qt.NoButton
+                            }
+                        }
+
+                        Button
+                        {
+                            id: resetFileName
+                            text: catalog.i18nc("@action", "Reset")
+                            onClicked:
+                            {
+                                manager.setUploadName(activeMachineId, "");
+                                uploadName.text = manager.uploadName(activeMachineId);
+                            }
+                        }
+                    }
+
                     Label
                     {
                         width: Math.floor(parent.width * 0.2)
@@ -346,6 +384,8 @@ Cura.MachineAction
                                 apiCheckDelay.lastKey = "\0";
                                 apiKey.text = manager.getApiKey(base.selectedInstance.getId());
                                 apiKey.select(0,0);
+                                uploadName.text = manager.uploadName(activeMachineId);
+                                uploadName.select(0,0);
                             }
                         }
                     }


### PR DESCRIPTION
This adds an additional option to `Connect OctoPrint` allowing to have a upload name with a different parameters, like: date or material used.

This makes it possible to quite easily when used with Octoprint effectively be able to store all uploads with adding `date` and `time`, or clearly annotate names with likely most common settings.

This also fixes support for `presliced` files, since the name and material support is affected by this.
We cannot send them in `UFP` format, as we cannot generate image for them,
and thus Octoprint returns `500 Internal server error`.

<img width="409" alt="Screenshot 2020-09-23 at 19 51 48" src="https://user-images.githubusercontent.com/2419009/94050537-afa6e300-fdd6-11ea-8b5f-b5a860da0428.png">
<img width="398" alt="Screenshot 2020-09-23 at 19 52 01" src="https://user-images.githubusercontent.com/2419009/94050544-b170a680-fdd6-11ea-85b2-5b6276e201cf.png">
