### PR TITLE
Structure fixes of MonitorItem4x

### DIFF
--- a/qml/MonitorItem4x.qml
+++ b/qml/MonitorItem4x.qml
@@ -166,8 +166,9 @@ Component
             {
                 right: parent.right
                 top: parent.top
+                topMargin: UM.Theme.getSize("default_margin").height
                 bottom: actionsPanel.top
-                margins: UM.Theme.getSize("default_margin").height
+                bottomMargin: UM.Theme.getSize("default_margin").height
             }
 
             border.width: UM.Theme.getSize("default_lining").width

--- a/qml/MonitorItem4x.qml
+++ b/qml/MonitorItem4x.qml
@@ -157,10 +157,32 @@ Component
             anchors.right: sidebar.left
         }
 
+        Cura.RoundedRectangle
+        {
+            id: sidebarBackground
+            anchors
+            {
+                top: parent.top
+                right: parent.right
+                bottom: actionsPanel.top
+                topMargin: UM.Theme.getSize("default_margin").height
+                bottomMargin: UM.Theme.getSize("default_margin").height
+            }
+
+            width: UM.Theme.getSize("print_setup_widget").width
+
+            color: UM.Theme.getColor("main_background")
+            border.width: UM.Theme.getSize("default_lining").width
+            border.color: UM.Theme.getColor("lining")
+
+            cornerSide: Cura.RoundedRectangle.Direction.Left
+            radius: UM.Theme.getSize("default_radius").width
+        }
+
         Cura.PrintMonitor {
             id: sidebar
 
-            width: UM.Theme.getSize("print_setup_widget").width
+            width: UM.Theme.getSize("print_setup_widget").width - UM.Theme.getSize("default_margin").height * 2
             anchors
             {
                 top: parent.top
@@ -173,6 +195,13 @@ Component
         Cura.RoundedRectangle
         {
             id: actionsPanel
+
+            border.width: UM.Theme.getSize("default_lining").width
+            border.color: UM.Theme.getColor("lining")
+            color: UM.Theme.getColor("main_background")
+
+            cornerSide: Cura.RoundedRectangle.Direction.Left
+            radius: UM.Theme.getSize("default_radius").width
 
             anchors.bottom: parent.bottom
             anchors.right: parent.right

--- a/qml/MonitorItem4x.qml
+++ b/qml/MonitorItem4x.qml
@@ -157,36 +157,16 @@ Component
             anchors.right: sidebar.left
         }
 
-        Cura.RoundedRectangle
-        {
+        Cura.PrintMonitor {
             id: sidebar
 
             width: UM.Theme.getSize("print_setup_widget").width
             anchors
             {
-                right: parent.right
                 top: parent.top
-                topMargin: UM.Theme.getSize("default_margin").height
+                right: parent.right
                 bottom: actionsPanel.top
-                bottomMargin: UM.Theme.getSize("default_margin").height
-            }
-
-            border.width: UM.Theme.getSize("default_lining").width
-            border.color: UM.Theme.getColor("lining")
-            color: UM.Theme.getColor("main_background")
-
-            cornerSide: Cura.RoundedRectangle.Direction.Left
-            radius: UM.Theme.getSize("default_radius").width
-
-            Cura.PrintMonitor {
-                width: parent.width
-                anchors
-                {
-                    left: parent.left
-                    leftMargin: UM.Theme.getSize("default_margin").width
-                    right: parent.right
-                    rightMargin: UM.Theme.getSize("default_margin").width
-                }
+                margins: UM.Theme.getSize("default_margin").width
             }
         }
 
@@ -194,18 +174,14 @@ Component
         {
             id: actionsPanel
 
-            border.width: UM.Theme.getSize("default_lining").width
-            border.color: UM.Theme.getColor("lining")
-            color: UM.Theme.getColor("main_background")
-
-            cornerSide: Cura.RoundedRectangle.Direction.Left
-            radius: UM.Theme.getSize("default_radius").width
-
             anchors.bottom: parent.bottom
             anchors.right: parent.right
 
+            anchors.bottomMargin: UM.Theme.getSize("default_margin").width
+            anchors.topMargin: UM.Theme.getSize("default_margin").height
+
             width: UM.Theme.getSize("print_setup_widget").width
-            height: monitorButton.height + UM.Theme.getSize("default_margin").height
+            height: monitorButton.height
 
             // MonitorButton is actually the bottom footer panel.
             Cura.MonitorButton
@@ -213,7 +189,6 @@ Component
                 id: monitorButton
                 width: parent.width
                 anchors.top: parent.top
-                anchors.topMargin: UM.Theme.getSize("default_margin").height
             }
         }
     }

--- a/qml/MonitorItem4x.qml
+++ b/qml/MonitorItem4x.qml
@@ -160,20 +160,19 @@ Component
         Cura.RoundedRectangle
         {
             id: sidebarBackground
-            anchors
-            {
-                top: parent.top
-                right: parent.right
-                bottom: actionsPanel.top
-                topMargin: UM.Theme.getSize("default_margin").height
-                bottomMargin: UM.Theme.getSize("default_margin").height
-            }
 
             width: UM.Theme.getSize("print_setup_widget").width
+            anchors
+            {
+                right: parent.right
+                top: parent.top
+                bottom: actionsPanel.top
+                margins: UM.Theme.getSize("default_margin").height
+            }
 
-            color: UM.Theme.getColor("main_background")
             border.width: UM.Theme.getSize("default_lining").width
             border.color: UM.Theme.getColor("lining")
+            color: UM.Theme.getColor("main_background")
 
             cornerSide: Cura.RoundedRectangle.Direction.Left
             radius: UM.Theme.getSize("default_radius").width
@@ -186,9 +185,10 @@ Component
             anchors
             {
                 top: parent.top
-                right: parent.right
                 bottom: actionsPanel.top
-                margins: UM.Theme.getSize("default_margin").width
+                leftMargin: UM.Theme.getSize("default_margin").width
+                right: parent.right
+                rightMargin: UM.Theme.getSize("default_margin").width
             }
         }
 


### PR DESCRIPTION
Monitor tab structure fixed;
QML warnings resolved;
Cura tooltips positions fixed.

Resolves this warnings in Cura log:

2020-12-19 17:51:23,817 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [406]: file:///Users/user/Library/Application Support/cura/4.8/plugins/OctoPrintPlugin/OctoPrintPlugin/qml/MonitorItem4x.qml:88: ReferenceError: stop is not defined
2020-12-19 17:51:23,819 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [406]: file:///Users/user/Library/Application Support/cura/4.8/plugins/OctoPrintPlugin/OctoPrintPlugin/qml/MonitorItem4x.qml:72: TypeError: Cannot read property of null
2020-12-19 17:51:23,822 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [406]: file:///Users/user/Library/Application Support/cura/4.8/plugins/OctoPrintPlugin/OctoPrintPlugin/qml/MonitorItem4x.qml:156: TypeError: Cannot read property of null
2020-12-19 17:51:23,824 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [406]: file:///Users/user/Library/Application Support/cura/4.8/plugins/OctoPrintPlugin/OctoPrintPlugin/qml/MonitorItem4x.qml:167: TypeError: Cannot read property of null
2020-12-19 17:51:23,826 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [406]: file:///Users/user/Library/Application Support/cura/4.8/plugins/OctoPrintPlugin/OctoPrintPlugin/qml/MonitorItem4x.qml:168: TypeError: Cannot read property of null
2020-12-19 17:51:23,829 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [406]: file:///Users/user/Library/Application Support/cura/4.8/plugins/OctoPrintPlugin/OctoPrintPlugin/qml/MonitorItem4x.qml:204: TypeError: Cannot read property of null
2020-12-19 17:51:23,831 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [406]: file:///Users/user/Library/Application Support/cura/4.8/plugins/OctoPrintPlugin/OctoPrintPlugin/qml/MonitorItem4x.qml:205: TypeError: Cannot read property of null
2020-12-19 17:51:23,834 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [406]: file:///Users/user/Library/Application Support/cura/4.8/plugins/OctoPrintPlugin/OctoPrintPlugin/qml/MonitorItem4x.qml:118: TypeError: Cannot read property of null
2020-12-19 17:51:23,836 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [406]: file:///Users/user/Library/Application Support/cura/4.8/plugins/OctoPrintPlugin/OctoPrintPlugin/qml/MonitorItem4x.qml:185: TypeError: Cannot read property of null
2020-12-19 17:51:23,839 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [406]: file:///Users/user/Library/Application Support/cura/4.8/plugins/OctoPrintPlugin/OctoPrintPlugin/qml/MonitorItem4x.qml:187: TypeError: Cannot read property of null
2020-12-19 17:51:23,958 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [406]: file:///Users/user/Library/Application Support/cura/4.8/plugins/OctoPrintPlugin/OctoPrintPlugin/qml/MonitorItem4x.qml:215: TypeError: Cannot read property of null

Screenshots:
Was:
![1](https://user-images.githubusercontent.com/812359/104812318-6d386480-5812-11eb-9902-7311f04b7f0a.jpeg)
![2](https://user-images.githubusercontent.com/812359/104812319-6f9abe80-5812-11eb-9bad-37bb83fdb3c1.jpeg)

Now:
![3](https://user-images.githubusercontent.com/812359/104812325-745f7280-5812-11eb-95b9-772820bda1d8.jpeg)
![4](https://user-images.githubusercontent.com/812359/104812328-75909f80-5812-11eb-93cb-18734cb27d53.jpeg)


Thanks @artemy for testing and screenshots