### PR TITLE
Add explicit conversion from float to int

### DIFF
--- a/OctoPrintOutputDevice.py
+++ b/OctoPrintOutputDevice.py
@@ -1181,7 +1181,7 @@ class OctoPrintOutputDevice(NetworkedPrinterOutputDevice):
                                 print_job.updateTimeTotal(print_time + print_time_left)
                             elif completion:  # not 0 or None or ""
                                 print_job.updateTimeTotal(
-                                    print_time / (completion / 100)
+                                    int(print_time / (completion / 100))
                                 )
                             else:
                                 print_job.updateTimeTotal(0)


### PR DESCRIPTION
I'm the packager of `cura` on Fedora, and I noticed that with the combination of Python 3.10, Cura 4.11+ and the latest version of this plugin, switching to the Monitor tab results in a crash.

```
Current thread 0x00007fa61491c740 (most recent call first):
  File "/usr/lib/python3.10/site-packages/cura/CrashHandler.py", line 396 in _logInfoWidget
  File "/usr/lib/python3.10/site-packages/cura/CrashHandler.py", line 182 in _createDialog
  File "/usr/lib/python3.10/site-packages/cura/CrashHandler.py", line 86 in __init__
  File "/usr/bin/cura", line 159 in exceptHook
  File "/usr/lib/python3.10/site-packages/cura/PrinterOutput/Models/PrintJobOutputModel.py", line 157 in updateTimeTotal
  File "/home/gabriel/.local/share/cura/4.12/plugins/OctoPrintPlugin/OctoPrintPlugin/OctoPrintOutputDevice.py", line 874 in _onRequestFinished
  File "/usr/lib/python3.10/site-packages/cura/PrinterOutput/NetworkedPrinterOutputDevice.py", line 370 in _handleOnFinished
```

At some point in time, I suppose the C++ bindings library dropped an implicit conversion somewhere in the code path.

This should be good enough to fix the issue!